### PR TITLE
docs: add a missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i vue-router-better-scroller
 In your main entry:
   
 ```ts
-import { createRouter, createWebHistory} from 'vue-router'
+import { createRouter, createWebHistory } from 'vue-router'
 import { createRouterScroller } from 'vue-router-better-scroller'
 import { createApp } from 'vue'
 import App from './App.vue'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm i vue-router-better-scroller
 In your main entry:
   
 ```ts
-import { createRouter } from 'vue-router'
+import { createRouter, createWebHistory} from 'vue-router'
 import { createRouterScroller } from 'vue-router-better-scroller'
 import { createApp } from 'vue'
 import App from './App.vue'


### PR DESCRIPTION
While reading the readme documentation, the example is missing the introduction of createWebHistory